### PR TITLE
xdebugのインストール

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // IntelliSense を使用して利用可能な属性を学べます。
+    // 既存の属性の説明をホバーして表示します。
+    // 詳細情報は次を確認してください: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/var/www/html":"${workspaceRoot}/src/"
+            }
+        }
+    ]
+}

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -27,6 +27,7 @@ server {
         fastcgi_pass app:9000;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_read_timeout 3600;
         include fastcgi_params;
     }
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -18,4 +18,6 @@ RUN apt-get update \
     vim \
     && docker-php-ext-install pdo_mysql bcmath
 
+RUN pecl install xdebug-3.1.4 && docker-php-ext-enable xdebug
+
 WORKDIR /var/www/html

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -3,3 +3,11 @@ date.timezone = "Asia/Tokyo"
 [mbstring]
 mbstring.internal_encoding = "UTF-8"
 mbstring.language = "Japanese"
+
+[xdebug]
+xdebug.mode=debug
+xdebug.start_with_request=yes
+xdebug.client_host=host.docker.internal
+xdebug.client_port=9003
+xdebug.log=/tmp/xdebug.log
+xdebug.log_level=0


### PR DESCRIPTION
## タスクリンク

* なし

## やったこと

* Docker環境にxdebugをインストール
https://www.bravesoft.co.jp/blog/archives/14082

* xdebug3から`xdebug.client_port=9003`になったため変更
https://xdebug.org/docs/upgrade_guide/ja
  >xdebug.remote_port [#](https://xdebug.org/docs/upgrade_guide/ja#changed-xdebug.remote_port)
[xdebug.client_port](https://xdebug.org/docs/all_settings#client_port) に置き換えられました。
デフォルト値は、9000 から 9003 に変更されました。

* デバッグから60秒以上経過してもnginxがタイムアウトしないように設定

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## UIスクショ

### 変更前

* なし

### 変更後

* なし

## 動作確認

`docker-compose up -d --build`を実行
- [x] ブレイクポイントを設置した箇所で止まる
- [x] ステップ実行できる
- [x] デバッグから60秒以上経過してもnginxがタイムアウトしない

## その他

* なし
