### PR TITLE
Inertiaフォームヘルパーの設置

### DIFF
--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -22,6 +22,8 @@
 </template>
 
 <script>
+import { useForm } from '@inertiajs/inertia-vue3';
+
 export default {
 
 }

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="mb-3">
+  <form
+    class="mb-3"
+    @submit.prevent="searchPlaces()"
+  >
     <label
       for="places-textarea"
       class="form-label"
@@ -19,7 +22,7 @@
     >
       おすすめの場所を検索
     </button>
-  </div>
+  </form>
 </template>
 
 <script>

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -25,7 +25,15 @@
 import { useForm } from '@inertiajs/inertia-vue3';
 
 export default {
+  setup() {
+    const form = useForm({
+      place: null,
+    });
 
+    return {
+      form,
+    };
+  },
 }
 </script>
 

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -8,6 +8,7 @@
     </label>
     <textarea
       id="places-textarea"
+      v-model="form.place"
       class="form-control"
       rows="3"
       placeholder="東京駅、東京タワー、東京スカイツリー"

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -31,8 +31,13 @@ export default {
       place: null,
     });
 
+    const searchPlaces = () => {
+      console.log('メソッド発火');
+    };
+
     return {
       form,
+      searchPlaces,
     };
   },
 }


### PR DESCRIPTION
## タスクリンク

* なし

## やったこと

* Inertiaフォームヘルパー設置
* `textarea`に上記フォームヘルパーを`v-model`でバインディング
* 場所検索メソッドを仮実装
* formをsubmit時、上記メソッドを発火

## やらないこと

* 場所検索メソッドを本格的に実装

## できるようになること（ユーザ目線）

* `textarea`に入力できる

## できなくなること（ユーザ目線）

* なし

## UIスクショ

### 変更前

 * なし

### 変更後

<img width="625" alt="スクリーンショット 2023-01-27 午前2 42 31" src="https://user-images.githubusercontent.com/76191551/214909597-711783c0-a4a1-4e9d-a5aa-880ebab5d46a.png">


## 動作確認

- [x] `textarea`に入力ができる
- [x] 「おすすめの場所を検索」ボタンクリック時、デベロッパーツールConsoleタブに「メソッド発火」と表示される

## その他

* なし
