### PR TITLE
GPT3（ChatGPT）のAPIを追加

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "dependencies": {
                 "@inertiajs/vue3": "^1.0.0",
+                "openai": "^3.1.0",
                 "vuedraggable": "^4.1.0"
             },
             "devDependencies": {
@@ -7388,6 +7389,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/openai": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-3.1.0.tgz",
+            "integrity": "sha512-v5kKFH5o+8ld+t0arudj833Mgm3GcgBnbyN9946bj6u7bvel4Yg6YFz2A4HLIYDzmMjIo0s6vSG9x73kOwvdCg==",
+            "dependencies": {
+                "axios": "^0.26.0",
+                "form-data": "^4.0.0"
+            }
+        },
+        "node_modules/openai/node_modules/axios": {
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+            "dependencies": {
+                "follow-redirects": "^1.14.8"
             }
         },
         "node_modules/optionator": {
@@ -16347,6 +16365,25 @@
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",
                 "is-wsl": "^2.2.0"
+            }
+        },
+        "openai": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-3.1.0.tgz",
+            "integrity": "sha512-v5kKFH5o+8ld+t0arudj833Mgm3GcgBnbyN9946bj6u7bvel4Yg6YFz2A4HLIYDzmMjIo0s6vSG9x73kOwvdCg==",
+            "requires": {
+                "axios": "^0.26.0",
+                "form-data": "^4.0.0"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "0.26.1",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+                    "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+                    "requires": {
+                        "follow-redirects": "^1.14.8"
+                    }
+                }
             }
         },
         "optionator": {

--- a/src/package.json
+++ b/src/package.json
@@ -30,6 +30,7 @@
     },
     "dependencies": {
         "@inertiajs/vue3": "^1.0.0",
+        "openai": "^3.1.0",
         "vuedraggable": "^4.1.0"
     }
 }

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -34,8 +34,24 @@ export default {
       place: null,
     });
 
-    const searchPlaces = () => {
+    const searchPlaces = async () => {
       console.log('メソッド発火');
+
+      const prompt = 'Google Apps Scriptの活用事例を教えてください';
+
+      const { Configuration, OpenAIApi } = require("openai");
+      const configuration = new Configuration({
+        apiKey: process.env.MIX_OPENAI_API_KEY,
+      });
+      const openai = new OpenAIApi(configuration);
+      const response = await openai.createCompletion({
+        model: "text-davinci-003",
+        prompt: prompt,
+        temperature: 0.9,
+        max_tokens: 1024,
+      });
+
+      console.log(response);
     };
 
     return {


### PR DESCRIPTION
## タスクリンク

* なし

## やったこと

* 下記のリンクを参考にOpenAIのAPIを使用
https://platform.openai.com/docs/libraries/node-js-library

## やらないこと

* 具体的な質問のパラメーター設定
* 返ってきた`response`の整形
* 上記をビューに表示
* 質問しやすいようにフォームなどのデザイン変更

## できるようになること（ユーザ目線）

* 「おすすめの場所を検索」クリックで、コンソールにGPT3の返答が見れる

## できなくなること（ユーザ目線）

* なし

## UIスクショ

### 変更前

 * なし

### 変更後

* なし

## 動作確認

- [x] 「おすすめの場所を検索」クリックで、コンソールにGPT3の返答が見れる

## その他

* なし
