### PR TITLE
古い検索結果のマーカーを削除

### DIFF
--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -120,6 +120,8 @@ export default {
         position: place.geometry.location,
       });
 
+      markers.push(marker);
+
       if (place.geometry.viewport) {
         bounds.union(place.geometry.viewport);
       } else {

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -62,6 +62,7 @@ export default {
     let map;
     let service;
     let bounds;
+    let markers = [];
 
     onMounted(() => {
       const loader = new Loader({

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -96,6 +96,11 @@ export default {
       if (status == google.maps.places.PlacesServiceStatus.OK) {
         bounds = new google.maps.LatLngBounds();
 
+        markers.forEach((marker) => {
+          marker.setMap(null);
+        });
+        markers = [];
+
         for (let i = 0; i < results.length; i++) {
           let place = results[i];
           createMarker(results[i]);


### PR DESCRIPTION
## タスクリンク

* なし

## やったこと

テキスト検索時、以前の検索結果のマーカーを削除。
「池袋　ラーメン」→「大阪難波　ラーメン」と検索すると、両方の検索結果のマーカーが表示されていた。（「池袋　ラーメン」のマーカーが残っていた）
「大阪難波　ラーメン」検索時には「池袋　ラーメン」のマーカーを削除する。
↓注意点
>複数のマーカーを削除するには、地図から除去して、次に配列の length を 0 に設定します。これで、マーカーへのすべての参照が除去されます。

https://developers.google.com/maps/documentation/javascript/markers?hl=ja#remove
https://developers.google.com/maps/documentation/javascript/examples/places-searchbox#:~:text=//%20Clear%20out%20the%20old%20markers.%0A%C2%A0%20%C2%A0%20markers.forEach((marker)%20%3D%3E%20%7B%0A%C2%A0%20%C2%A0%20%C2%A0%20marker.setMap(null)%3B%0A%C2%A0%20%C2%A0%20%7D)%3B%0A%C2%A0%20%C2%A0%20markers%20%3D%20%5B%5D%3B

## やらないこと

* なし

## できるようになること（ユーザ目線）

* テキスト検索時、以前の検索結果のマーカーが消えるのを確認できる

## できなくなること（ユーザ目線）

* なし

## UIスクショ

### 変更前

<img width="2002" alt="スクリーンショット 2023-03-07 午後4 50 35" src="https://user-images.githubusercontent.com/76191551/223370901-c6fdee19-f8ce-4429-a0d1-16dc4e51f40a.png">


### 変更後

なし

## 動作確認

- [x] テキスト検索時、以前の検索結果のマーカーが消える

## その他

* なし
