### PR TITLE
Feature/open infowindow when clicking marker

### DIFF
--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -128,6 +128,7 @@ export default {
       });
 
       marker.addListener('click', () => {
+        infoWindow.close();
       });
 
       markers.push(marker);

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -64,6 +64,8 @@ export default {
     let bounds;
     let markers = [];
 
+    let photoUrl = ref('');
+
     onMounted(() => {
       const loader = new Loader({
         apiKey: process.env.MIX_GOOGLE_MAPS_API_KEY,

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -123,6 +123,8 @@ export default {
       const marker = new google.maps.Marker({
         map,
         position: place.geometry.location,
+        title: place.name,
+        optimized: false,
       });
 
       markers.push(marker);

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -130,6 +130,7 @@ export default {
       marker.addListener('click', () => {
         infoWindow.close();
         infoWindow.setContent(marker.getTitle());
+        infoWindow.open(marker.getMap(), marker);
       });
 
       markers.push(marker);

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -129,6 +129,7 @@ export default {
 
       marker.addListener('click', () => {
         infoWindow.close();
+        infoWindow.setContent(marker.getTitle());
       });
 
       markers.push(marker);

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -127,6 +127,9 @@ export default {
         optimized: false,
       });
 
+      marker.addListener('click', () => {
+      });
+
       markers.push(marker);
 
       if (place.geometry.viewport) {

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -29,7 +29,7 @@
 <script>
 import { useForm } from '@inertiajs/vue3';
 import { Loader } from "@googlemaps/js-api-loader";
-import { onMounted } from 'vue';
+import { onMounted, ref } from 'vue';
 
 export default {
   setup() {

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -99,6 +99,7 @@ export default {
     const callback = (results, status) => {
       if (status == google.maps.places.PlacesServiceStatus.OK) {
         bounds = new google.maps.LatLngBounds();
+        infoWindow = new google.maps.InfoWindow();
 
         markers.forEach((marker) => {
           marker.setMap(null);

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -24,7 +24,10 @@
     </button>
   </form>
   <div id="map" />
-  <img :src="photoUrl" alt="">
+  <img
+    :src="photoUrl"
+    alt=""
+  >
 </template>
 
 <script>

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -63,6 +63,7 @@ export default {
     let service;
     let bounds;
     let markers = [];
+    let infoWindow;
 
     let photoUrl = ref('');
 

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -135,6 +135,7 @@ export default {
     return {
       form,
       searchPlaces,
+      photoUrl,
     };
   },
 }

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -24,6 +24,7 @@
     </button>
   </form>
   <div id="map" />
+  <img :src="photoUrl" alt="">
 </template>
 
 <script>

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -131,6 +131,8 @@ export default {
         infoWindow.close();
         infoWindow.setContent(marker.getTitle());
         infoWindow.open(marker.getMap(), marker);
+
+        photoUrl.value = place.photos[0].getUrl();
       });
 
       markers.push(marker);


### PR DESCRIPTION
## タスクリンク

* なし

## やったこと

### マーカーをアクセス可能にする

>クリック リスナー イベントを追加し、`optimized` を `false` に設定すると、マーカーをアクセス可能にできる。

https://developers.google.com/maps/documentation/javascript/markers?hl=ja#accessible

### マーカークリック時、場所名が表示されている情報ウィンドウを表示する

InfoWindowインスタンスは、全マーカー間で共有する。
そのため、`markers`の繰り返しの`forEach`でインスタンス生成をしない。

マーカーのクリックイベントに下記流れで処理を追加した。

1. `infoWindow.close();`：現在開いている情報ウィンドウを閉じる
2. `infoWindow.setContent(marker.getTitle());`：マーカーのタイトルをコンテンツにセットする
3. `infoWindow.open(marker.getMap(), marker);`：クリックしたマーカーの所に、情報ウィンドウを表示する

https://developers.google.com/maps/documentation/javascript/markers?hl=ja#accessible
https://developers.google.com/maps/documentation/javascript/reference/info-window?hl=ja#InfoWindow
https://developers.google.com/maps/documentation/javascript/reference/marker?hl=ja#Marker

### マーカークリック時、その場所の写真を表示する

>`textSearch()`リクエストを実行すると、PlaceResult オブジェクトの一部として PlacePhoto オブジェクトの配列が返されます
返される写真の数はText Search では、PlacePhoto オブジェクトが 1 つのみ返されます。
関連画像の URL をリクエストするには、PlacePhoto.getUrl() メソッドを呼び出す

マーカーのクリックイベントに上記処理を追加。
マーカークリック時に、その場所の写真のURLをリアクティブな変数に代入する。
リアクティブな変数は、`img`要素の`:src`とバインディングしているので、変数変更時（つまり、マーカークリック時）に写真が切り替わる。

https://developers.google.com/maps/documentation/javascript/places?hl=ja#places_photos

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 検索結果のマーカーをクリックできる
* マーカークリック時、場所名が表示されている情報ウィンドウを確認できる
* マーカークリック時、その場所の写真を確認できる

## できなくなること（ユーザ目線）

* なし

## UIスクショ

### 変更前

なし

### 変更後


https://user-images.githubusercontent.com/76191551/224610769-b1edfd3b-019c-47f2-9852-b00bbcdb76e7.mov



## 動作確認

- [x] マーカークリック時、場所名が表示されている情報ウィンドウが表示される
- [x] マーカークリック時、その場所の写真が地図の下に表示される

## その他

* なし
