### PR TITLE
`text-davinci-003`から`gpt-3.5-turbo`へ変更

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -7,7 +7,7 @@
             "dependencies": {
                 "@googlemaps/js-api-loader": "^1.15.1",
                 "@inertiajs/vue3": "^1.0.0",
-                "openai": "^3.1.0",
+                "openai": "^3.2.1",
                 "vuedraggable": "^4.1.0"
             },
             "devDependencies": {
@@ -7400,9 +7400,9 @@
             }
         },
         "node_modules/openai": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-3.1.0.tgz",
-            "integrity": "sha512-v5kKFH5o+8ld+t0arudj833Mgm3GcgBnbyN9946bj6u7bvel4Yg6YFz2A4HLIYDzmMjIo0s6vSG9x73kOwvdCg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-3.2.1.tgz",
+            "integrity": "sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==",
             "dependencies": {
                 "axios": "^0.26.0",
                 "form-data": "^4.0.0"
@@ -16383,9 +16383,9 @@
             }
         },
         "openai": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-3.1.0.tgz",
-            "integrity": "sha512-v5kKFH5o+8ld+t0arudj833Mgm3GcgBnbyN9946bj6u7bvel4Yg6YFz2A4HLIYDzmMjIo0s6vSG9x73kOwvdCg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-3.2.1.tgz",
+            "integrity": "sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==",
             "requires": {
                 "axios": "^0.26.0",
                 "form-data": "^4.0.0"

--- a/src/package.json
+++ b/src/package.json
@@ -31,7 +31,7 @@
     "dependencies": {
         "@googlemaps/js-api-loader": "^1.15.1",
         "@inertiajs/vue3": "^1.0.0",
-        "openai": "^3.1.0",
+        "openai": "^3.2.1",
         "vuedraggable": "^4.1.0"
     }
 }

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -51,11 +51,9 @@ export default {
         apiKey: process.env.MIX_OPENAI_API_KEY,
       });
       const openai = new OpenAIApi(configuration);
-      const response = await openai.createCompletion({
-        model: "text-davinci-003",
-        prompt: prompt,
-        temperature: 0.9,
-        max_tokens: 1024,
+      const response = await openai.createChatCompletion({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: "Hello world" }],
       });
 
       console.log(response);


### PR DESCRIPTION
## タスクリンク

* なし

## やったこと

### `gpt-3.5-turbo`を使えるようにする

`npm install openai`を実行して、ライブラリをアップデートする。

### `gpt-3.5-turbo`をお試し使用

公式リファレンスを参考に変更。
https://platform.openai.com/docs/api-reference/chat

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* なし

## UIスクショ

### 変更前

なし

### 変更後

なし

## 動作確認

- [x] 検索ボタンを押すと、デベロッパーツールのコンソールに、`gpt-3.5-turbo`のレスポンスが返ってくる

## その他

* なし
