### PR TITLE
フォームに入力した内容をもとに、ChatGPT回答とGoogle Mapで検索をする

### DIFF
--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -53,7 +53,11 @@ export default {
       const openai = new OpenAIApi(configuration);
       const response = await openai.createChatCompletion({
         model: "gpt-3.5-turbo",
-        messages: [{ role: "user", content: "Hello world" }],
+        messages: [
+          { role: "system", content: process.env.MIX_SYSTEM_CONTENT },
+          { role: "user", content: process.env.MIX_PROMPT },
+          { role: "user", content: form.place },
+        ],
       });
 
       console.log(response);

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -60,7 +60,10 @@ export default {
         ],
       });
 
-      console.log(response);
+      const messageContent = response.data.choices[0].message.content;
+      const regex = new RegExp(process.env.MIX_REGEX);
+      const results = messageContent.match(regex);
+      const recommendedPlace = results[1];
 
       searchPlacesWithGoogleMaps()
     };

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -65,7 +65,7 @@ export default {
       const results = messageContent.match(regex);
       const recommendedPlace = results[1];
 
-      searchPlacesWithGoogleMaps()
+      searchPlacesWithGoogleMaps(recommendedPlace);
     };
 
     let map;
@@ -95,9 +95,9 @@ export default {
       });
     });
 
-    const searchPlacesWithGoogleMaps = () => {
+    const searchPlacesWithGoogleMaps = (recommendedPlace) => {
       let request = {
-        query: form.place,
+        query: recommendedPlace,
       };
 
       service = new google.maps.places.PlacesService(map);


### PR DESCRIPTION
## タスクリンク

* なし

## やったこと

### フォームに入力した内容をもとに、ChatGPTの回答を取得する

あらかじめ用意しておいたプロンプトとフォームの内容をチャット形式で渡し、回答を得る。
得られた回答は場所の文字列以外にも、必要のない文字列が含まれている。
そのため、得られた回答の文字列全体から、場所の文字列のみを取得する。
`RegExp`で正規表現を生成し、`match()`で取得する。
なお、取得したい文字列は、`match()`の戻り値の配列の、2番めの要素（要素のインデックスが1）なので注意。

### ChatGPTの回答をGoogle Mapで検索する

`searchPlacesWithGoogleMaps()`に引数として、上記で得られた文字列を渡す。

## やらないこと

* なし

## できるようになること（ユーザ目線）

* フォームに入力し、検索すると、Google Mapにおすすめの場所が表示される

## できなくなること（ユーザ目線）

* なし

## UIスクショ

### 変更前

 * なし

### 変更後

* なし

## 動作確認

- [x] フォームに入力し、検索すると、Google Mapにおすすめの場所が表示される

## その他

* なし
