### PR TITLE
Bootstrapでフロントエンドのデザインを改良

### DIFF
--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -38,6 +38,7 @@
           <img
             :src="photoUrl"
             alt=""
+            class="img-fluid"
           >
         </div>
       </div>

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -13,7 +13,7 @@
       <textarea
         id="places-textarea"
         v-model="form.place"
-      class="form-control"
+        class="form-control mb-3"
         rows="3"
         placeholder="東京駅、東京タワー、東京スカイツリー"
       />

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -26,13 +26,17 @@
     </form>
     <div class="row">
       <div class="col-sm-6">
+        <div class="ratio ratio-1x1">
   <div id="map" />
+        </div>
       </div>
       <div class="col-sm-6">
+        <div class="ratio ratio-1x1">
           <img
             :src="photoUrl"
             alt=""
           >
+        </div>
       </div>
     </div>
   </div>

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -24,11 +24,17 @@
         おすすめの場所を検索
       </button>
     </form>
+    <div class="row">
+      <div class="col-sm-6">
   <div id="map" />
+      </div>
+      <div class="col-sm-6">
           <img
             :src="photoUrl"
             alt=""
           >
+      </div>
+    </div>
   </div>
 </template>
 

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -27,7 +27,10 @@
     <div class="row">
       <div class="col-sm-6">
         <div class="ratio ratio-1x1">
-  <div id="map" />
+          <div
+            id="map"
+            class="h-100"
+          />
         </div>
       </div>
       <div class="col-sm-6">

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <form
-    class="mb-3"
+      class="mb-3 text-center"
       @submit.prevent="searchPlaces()"
     >
       <label

--- a/src/resources/js/Pages/SearchPlaces/Index.vue
+++ b/src/resources/js/Pages/SearchPlaces/Index.vue
@@ -1,33 +1,35 @@
 <template>
-  <form
+  <div class="container">
+    <form
     class="mb-3"
-    @submit.prevent="searchPlaces()"
-  >
-    <label
-      for="places-textarea"
-      class="form-label"
+      @submit.prevent="searchPlaces()"
     >
-      行く予定の場所
-    </label>
-    <textarea
-      id="places-textarea"
-      v-model="form.place"
+      <label
+        for="places-textarea"
+        class="form-label"
+      >
+        行く予定の場所
+      </label>
+      <textarea
+        id="places-textarea"
+        v-model="form.place"
       class="form-control"
-      rows="3"
-      placeholder="東京駅、東京タワー、東京スカイツリー"
-    />
-    <button
-      class="btn btn-primary"
-      type="submit"
-    >
-      おすすめの場所を検索
-    </button>
-  </form>
+        rows="3"
+        placeholder="東京駅、東京タワー、東京スカイツリー"
+      />
+      <button
+        class="btn btn-primary"
+        type="submit"
+      >
+        おすすめの場所を検索
+      </button>
+    </form>
   <div id="map" />
-  <img
-    :src="photoUrl"
-    alt=""
-  >
+          <img
+            :src="photoUrl"
+            alt=""
+          >
+  </div>
 </template>
 
 <script>
@@ -162,7 +164,4 @@ export default {
 </script>
 
 <style scoped>
-#map {
-  height: 500px;
-}
 </style>


### PR DESCRIPTION
## タスクリンク

* なし

## やったこと

### 全体を中央配置、左右に余白を設定

`<tamplate>`直下に`.container`のdiv要素を配置。フォームや地図などの要素を、そのdiv要素内に配置する。

### form要素内の要素を水平方向の中央に配置

formタグに`.text-center`を付与するだけで、水平方向の中央に配置できる。
<!-- flexboxを使わなくても、簡単にできることを学んだ。なぜ複雑にする必要があるのか -->
また、textareaの下にマージンを設置

### 地図と画像をレスポンシブ対応

グリッドシステム、`ratio-1x1`、地図には`.h-100`、画像には`.img-fluid`を使用した。
全体を`.row`で囲み、その直下に`.col-sm-6`で、地図と画像を並べて表示する。
`.col-sm-6`直下で、地図と画像のアスペクト比を1x1にする。
`.ratio-1x1`で要素の高さが設定されるため、地図のdiv要素に`.h-100`付与する。このおかげで、CSSで高さを設定しなくても地図が表示される。ちなみに、`height: 500px;`などで高さを設定すると、画面サイズ変更時、引き伸ばされてしまう。

## やらないこと

* なし

## できるようになること（ユーザ目線）

* PCなどでは、地図と画像は並んで表示されるのを確認できる
* スマホなどでは、地図と画像が縦並びで表示されるのを確認できる

## できなくなること（ユーザ目線）

* なし

## UIスクショ

### 変更前

なし

### 変更後

<img width="1492" alt="スクリーンショット 2023-04-06 午後1 12 05" src="https://user-images.githubusercontent.com/76191551/230270351-60fa3b94-797a-4636-a577-271b92532cdc.png">

<img width="438" alt="スクリーンショット 2023-04-06 午後1 12 36" src="https://user-images.githubusercontent.com/76191551/230270373-843415f2-2ceb-4c00-9698-d0d368abaede.png">


## 動作確認

- [x] 全体が中央配置、左右に余白が設定されている
- [x] 「行く予定の場所」のlabel要素が水平方向の中央に配置されている
- [x] 検索ボタンが水平方向の中央に配置されている
- [x] 画面がPCサイズでは、地図と画像が横並びで表示されている
- [x] 画面がスマホサイズでは、地図と画像が縦並びで表示されている
- [x] 画面サイズ変更時、地図と画像のアスペクト比が1x1で維持される
- [x] 画面サイズ変更時、地図と画像が引き伸ばされて表示されない

## その他

* コードレビューの際、Hide whitespaceした方が見やすい。
